### PR TITLE
support defining AZs through account mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To configure your AZ settings, set `az_mapping` to true
 az_mapping: true
 ```
 
-Then configure a map in the following structure to define your AZs
+Then configure a [Map](https://github.com/theonestack/cfhighlander#cloudformation-mappings) in the following structure to define your AZs
 
 ```yaml
 Accounts:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,49 @@ kurgan add vpc-v2
 
 ## Configuration
 
+### Selecting Availability Zones
+
+By default the `vpc-v2` component will automatically select the AZs. This is achieved by looping over the `max_availability_zones` count and using the `Fn::GetAZs` Cloudformation function to select the AZ id.
+
+```rb
+max_availability_zones.times |az|
+  selected_az = FnSelect(az, FnGetAZs(Ref('AWS::Region')))
+end
+```
+
+However if you wish to define which as AZs you want to use you can by configuring a map per AWS account with the AZs you wish to use. 
+**NOTE:** the total count of AZ's defined in the map for each account has to be the same value as `max_availability_zones`.
+
+To configure your AZ settings, set `az_mapping` to true
+
+```yaml
+az_mapping: true
+```
+
+Then configure a map in the following structure to define your AZs
+
+```yaml
+Accounts:
+  '000000000000': # AWS Account Id
+    AZs: '3,5,0' # Comma delimited list of numerical values that maps to the Availability Zone for that account
+```
+
+the numerical values will map to the Availability Zone retuned from the `Fn::GetAZs` function in the AWS account. For example in `us-east-1` returns
+
+```rb
+[ "us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1e", "us-east-1f" ]
+```
+
+therefore the mapping `AZs: '3,5,0'` will use AZs `[ "us-east-1d", "us-east-1f", "us-east-1a" ]`
+
+the new function to retrieve the AZ becomes
+
+```rb
+max_availability_zones.times |az|
+  selected_az = FnSelect(FnSelect(az, FnSplit(',', FnFindInMap('Accounts', Ref('AWS::AccountId'), 'AZs'))), FnGetAZs(Ref('AWS::Region')))
+end
+```
+
 ### Subnetting
 
 **Subnet Allocation**

--- a/spec/az_mapping_spec.rb
+++ b/spec/az_mapping_spec.rb
@@ -1,0 +1,89 @@
+require 'yaml'
+
+describe 'compiled component' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/az_mapping.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/az_mapping/vpc-v2.compiled.yaml") }
+  
+  context 'Resource SubnetPublic0' do
+
+    let(:properties) { template["Resources"]["SubnetPublic0"]["Properties"] }
+
+    it 'has property VpcId' do
+      expect(properties["VpcId"]).to eq({"Ref"=>"VPC"})
+    end
+
+    it 'has property CidrBlock' do
+      expect(properties["CidrBlock"]).to eq({"Fn::Select" => [0, {"Fn::Cidr"=>[{"Ref"=>"CIDR"}, 16, {"Ref"=>"SubnetBits"}]}]})
+    end
+
+    it 'has property AvailabilityZone' do
+      expect(properties["AvailabilityZone"]).to eq({"Fn::Select"=>[{"Fn::Select"=>[0, {"Fn::Split"=>[",", {"Fn::FindInMap"=>["Accounts", {"Ref"=> "AWS::AccountId"}, "AZs"]}]}]}, {"Fn::GetAZs"=>{"Ref"=>"AWS::Region"}}]})
+    end
+
+    it 'has property Tags' do
+      expect(properties["Tags"]).to include({"Key"=>"Name", "Value"=>{"Fn::Sub"=>["${EnvironmentName}-public-${AZ}", {"AZ"=>{"Fn::Select"=>[{"Fn::Select"=>[0, {"Fn::Split"=>[",", {"Fn::FindInMap"=>["Accounts", {"Ref"=> "AWS::AccountId"}, "AZs"]}]}]}, {"Fn::GetAZs"=>{"Ref"=>"AWS::Region"}}]}}]}})
+      expect(properties["Tags"]).to include({"Key"=>"Type", "Value"=>"public"})
+      expect(properties["Tags"]).to include({"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}})
+      expect(properties["Tags"]).to include({"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}})
+    end
+
+  end
+
+  context 'Resource SubnetPublic1' do
+
+    let(:properties) { template["Resources"]["SubnetPublic1"]["Properties"] }
+
+    it 'has property VpcId' do
+      expect(properties["VpcId"]).to eq({"Ref"=>"VPC"})
+    end
+
+    it 'has property CidrBlock' do
+      expect(properties["CidrBlock"]).to eq({"Fn::Select" => [1, {"Fn::Cidr"=>[{"Ref"=>"CIDR"}, 16, {"Ref"=>"SubnetBits"}]}]})
+    end
+
+    it 'has property AvailabilityZone' do
+      expect(properties["AvailabilityZone"]).to eq({"Fn::Select"=>[{"Fn::Select"=>[1, {"Fn::Split"=>[",", {"Fn::FindInMap"=>["Accounts", {"Ref"=> "AWS::AccountId"}, "AZs"]}]}]}, {"Fn::GetAZs"=>{"Ref"=>"AWS::Region"}}]})
+    end
+
+    it 'has property Tags' do
+      expect(properties["Tags"]).to include({"Key"=>"Name", "Value"=>{"Fn::Sub"=>["${EnvironmentName}-public-${AZ}", {"AZ"=>{"Fn::Select"=>[{"Fn::Select"=>[1, {"Fn::Split"=>[",", {"Fn::FindInMap"=>["Accounts", {"Ref"=> "AWS::AccountId"}, "AZs"]}]}]}, {"Fn::GetAZs"=>{"Ref"=>"AWS::Region"}}]}}]}})
+      expect(properties["Tags"]).to include({"Key"=>"Type", "Value"=>"public"})
+      expect(properties["Tags"]).to include({"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}})
+      expect(properties["Tags"]).to include({"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}})
+    end
+
+  end
+
+  context 'Resource SubnetPublic2' do
+
+    let(:properties) { template["Resources"]["SubnetPublic2"]["Properties"] }
+
+    it 'has property VpcId' do
+      expect(properties["VpcId"]).to eq({"Ref"=>"VPC"})
+    end
+
+    it 'has property CidrBlock' do
+      expect(properties["CidrBlock"]).to eq({"Fn::Select" => [2, {"Fn::Cidr"=>[{"Ref"=>"CIDR"}, 16, {"Ref"=>"SubnetBits"}]}]})
+    end
+
+    it 'has property AvailabilityZone' do
+      expect(properties["AvailabilityZone"]).to eq({"Fn::Select"=>[{"Fn::Select"=>[2, {"Fn::Split"=>[",", {"Fn::FindInMap"=>["Accounts", {"Ref"=> "AWS::AccountId"}, "AZs"]}]}]}, {"Fn::GetAZs"=>{"Ref"=>"AWS::Region"}}]})
+    end
+
+    it 'has property Tags' do
+      expect(properties["Tags"]).to include({"Key"=>"Name", "Value"=>{"Fn::Sub"=>["${EnvironmentName}-public-${AZ}", {"AZ"=>{"Fn::Select"=>[{"Fn::Select"=>[2, {"Fn::Split"=>[",", {"Fn::FindInMap"=>["Accounts", {"Ref"=> "AWS::AccountId"}, "AZs"]}]}]}, {"Fn::GetAZs"=>{"Ref"=>"AWS::Region"}}]}}]}})
+      expect(properties["Tags"]).to include({"Key"=>"Type", "Value"=>"public"})
+      expect(properties["Tags"]).to include({"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}})
+      expect(properties["Tags"]).to include({"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}})
+    end
+
+  end
+
+end
+

--- a/tests/az_mapping.test.yaml
+++ b/tests/az_mapping.test.yaml
@@ -1,0 +1,6 @@
+test_metadata:
+  type: config
+  name: az_mapping
+  description: defing the az's through a map
+
+az_mapping: true

--- a/vpc-v2.config.yaml
+++ b/vpc-v2.config.yaml
@@ -1,4 +1,5 @@
 max_availability_zones: 3
+az_mapping: false
 subnet_multiplyer: 4
 
 vpc_cidr: 10.0.0.0/16


### PR DESCRIPTION
### Selecting Availability Zones

By default the `vpc-v2` component will automatically select the AZs. This is achieved by looping over the `max_availability_zones` count and using the `Fn::GetAZs` Cloudformation function to select the AZ id.

```rb
max_availability_zones.times |az|
  selected_az = FnSelect(az, FnGetAZs(Ref('AWS::Region')))
end
```

However if you wish to define which as AZs you want to use you can by configuring a map per AWS account with the AZs you wish to use. 
**NOTE:** the total count of AZ's defined in the map for each account has to be the same value as `max_availability_zones`.

To configure your AZ settings, set `az_mapping` to true

```yaml
az_mapping: true
```

Then configure a map in the following structure to define your AZs

```yaml
Accounts:
  '000000000000': # AWS Account Id
    AZs: '3,5,0' # Comma delimited list of numerical values that maps to the Availability Zone for that account
```

the numerical values will map to the Availability Zone retuned from the `Fn::GetAZs` function in the AWS account. For example in `us-east-1` returns

```rb
[ "us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1e", "us-east-1f" ]
```

therefore the mapping `AZs: '3,5,0'` will use AZs `[ "us-east-1d", "us-east-1f", "us-east-1a" ]`

the new function to retrieve the AZ becomes

```rb
max_availability_zones.times |az|
  selected_az = FnSelect(FnSelect(az, FnSplit(',', FnFindInMap('Accounts', Ref('AWS::AccountId'), 'AZs'))), FnGetAZs(Ref('AWS::Region')))
end
```