### PR TITLE
Changing type of ComponentParam NatAmi to String

### DIFF
--- a/vpc-v2.cfhighlander.rb
+++ b/vpc-v2.cfhighlander.rb
@@ -55,7 +55,7 @@ CfhighlanderTemplate do
       allowedValues: ['managed','instances','disabled']
       
     ComponentParam 'NatAmi', '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs',
-      type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+      type: 'String'
       
     ComponentParam 'NatInstanceType', 't3.nano'
     


### PR DESCRIPTION
While deploying the template CFN fails to reference the NatAmi.

- Template:
```ruby
CfhighlanderTemplate do
  Name 'training-task4'
  Description "training-task4"

  Component name: 'vpcv2', template: 'vpc-v2'

end
```
- Component config:
```yaml
---
max_availability_zones: 2
subnet_multiplyer: 2
vpc_cidr: 10.0.0.0/16
subnet_mask: 24
subnets:
  persistence:
    enable: false
  cache:
    enable: false
acl_rules:
  - acl: public
    number: 100
    from: 80
    ips:
      - public
  - acl: public
    number: 200
    from: 443
    ips:
      - public
  - acl: public
    number: 300
    from: 1024
    to: 65535
    ips:
      - public
  - acl: public
    egress: true
    number: 100
    protocol: -1
    ips:
      - public
  - acl: private
    number: 100
    protocol: -1
    ips:
      - public
  - acl: private
    number: 100
    egress: true
    protocol: -1
    ips:
      - public
create_hosted_zone: false
```
- Parameters:
<img width="1030" alt="Captura de Tela 2021-06-23 às 21 33 27" src="https://user-images.githubusercontent.com/28915474/123184849-efd0ea00-d46a-11eb-8c91-7f90e305bfdf.png">

- Error:
<img src="https://user-images.githubusercontent.com/28915474/123184910-1d1d9800-d46b-11eb-97ff-772c63e6348b.png">

Changing the type of the parameter NatAmi to String fix this issue, as pointed here: https://stackoverflow.com/a/58295326.
