### PR TITLE
Removing duplicated key

### DIFF
--- a/vpc-v2.cfhighlander.rb
+++ b/vpc-v2.cfhighlander.rb
@@ -55,7 +55,7 @@ CfhighlanderTemplate do
       allowedValues: ['managed','instances','disabled']
       
     ComponentParam 'NatAmi', '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs',
-      type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+      type: 'String'
       
     ComponentParam 'NatInstanceType', 't3.nano'
     

--- a/vpc-v2.config.yaml
+++ b/vpc-v2.config.yaml
@@ -54,7 +54,6 @@ acl_rules:
     acl: private
     egress: true
     number: 100
-    egress: true
     protocol: -1
     ips:
       - public


### PR DESCRIPTION
Removing duplicated egress key in the config.yaml file, which can cause some syntax errors depending on which yaml parser is being used.